### PR TITLE
rename hookimpl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 napari-plugin-engine
-magicgui
 scikit-image

--- a/skimage_widgets/plugin.py
+++ b/skimage_widgets/plugin.py
@@ -2,7 +2,7 @@ from napari_plugin_engine import napari_hook_implementation
 
 
 @napari_hook_implementation
-def napari_experimental_provide_function_widget():
+def napari_experimental_provide_function():
     from .annotate import annotate_module
     from skimage import filters
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ passenv =
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
 deps = 
+    magicgui
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-xvfb ; sys_platform == 'linux'


### PR DESCRIPTION
Renames hook_impl for `0.4.4` release, and moves magicgui to test dependencies