### PR TITLE
Add returns type info

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 napari-plugin-engine
-magicgui
 scikit-image

--- a/skimage_widgets/annotate.py
+++ b/skimage_widgets/annotate.py
@@ -76,6 +76,13 @@ def guess_type(param: inspect.Parameter, doc_type):
         return type(param.default)
 
 
+def guess_return_type(doc_type):
+    if "array of bool" in doc_type:
+        return "napari.types.LabelsData"
+    if "array" in doc_type:
+        return "napari.types.ImageData"
+
+
 def annotate_function(function):
     sig = inspect.signature(function)
     doc_params = {p.arg_name: p.type_name for p in parse(function.__doc__).params}
@@ -86,6 +93,13 @@ def annotate_function(function):
             del doc_params[k]
     for p in sig.parameters.values():
         function.__annotations__[p.name] = guess_type(p, doc_params.get(p.name))
+    
+    doc_returns = parse(function.__doc__).returns
+    # Note skimage.filters.inverse has no return doc string
+    # Note skimage.filters.threshold should be a different type ....
+    if doc_returns is not None:
+        doc_returns_type = doc_returns.type_name
+        function.__annotations__['return'] = guess_return_type(doc_returns_type)
 
 
 def annotate_module(module):

--- a/skimage_widgets/plugin.py
+++ b/skimage_widgets/plugin.py
@@ -2,7 +2,7 @@ from napari_plugin_engine import napari_hook_implementation
 
 
 @napari_hook_implementation
-def napari_experimental_provide_function_widget():
+def napari_experimental_provide_function():
     from .annotate import annotate_module
     from skimage import filters
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ passenv =
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
 deps = 
+    magicgui
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-xvfb ; sys_platform == 'linux'


### PR DESCRIPTION
This PR is a poor attempt at adding some return type info, which doesn't do so good for all cases, but does ok for some. There are probably nicer ways to do this and we probably don't want to merge this as is, but I needed to do something in order to see an output in the gui! Curious if you have more ideas @tlambert03?

Note PR includes changes from #2 too.

![skimage-widgets](https://user-images.githubusercontent.com/6531703/105944491-3f280100-6018-11eb-9f76-26deadc1a96e.gif)
